### PR TITLE
fix default MQTT port setting for UNIX socket connection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.3.1) stable; urgency=medium
+
+  * Fix default port setting in bullseye for UNIX socket connection
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 04 Oct 2022 20:12:58 +0600
+
 wb-mqtt-mbgate (1.3.0) stable; urgency=medium
 
   * Support connection to Mosquitto through unix socket

--- a/utils/generate_config.py
+++ b/utils/generate_config.py
@@ -22,7 +22,6 @@ RESERVED_UNIT_IDS = [1, 2]
 RESERVED_UNIT_IDS += list(range(247, 256)) + [0]
 
 DEFAULT_MOSQUITTO_SOCKET_PATH = "unix:///var/run/mosquitto/mosquitto.sock"
-DEFAULT_MOSQUITTO_SERVER = "localhost"
 DEFAULT_MOSQUITTO_PORT = 1883
 
 client = None
@@ -279,16 +278,18 @@ def main(args=None):
         config_file = open(args.config, "w")
 
     client_id = str(time.time()) + str(random.randint(0, 100000))
-    hostname = args.server
-    port = args.port
     
     url = urllib.parse.urlparse(args.server)
     if url.scheme == 'unix':
         client = paho_socket.Client(client_id)
         client.sock_connect(url.path)
+        hostname = url.path
+        port = 0  # means UNIX socket connection for wbmqtt
     else:
         client = mqtt.Client(client_id)
         client.connect(args.server, args.port)
+        hostname = args.server
+        port = args.port
 
     client.on_message = mqtt_on_message
 

--- a/wb-mqtt-mbgate.schema.json
+++ b/wb-mqtt-mbgate.schema.json
@@ -260,7 +260,7 @@
                     "title": "Port",
                     "description": "Broker port",
                     "default": 1883,
-                    "minimum": 1,
+                    "minimum": 0,
                     "maximum": 65535,
                     "propertyOrder": 20,
                     "options": {


### PR DESCRIPTION
После обновления на bullseye у меня не поднялся wb-mqtt-mbgate, потому что в конфиге вместе с путём до сокета был прописан порт 1883, что неправильно понимается библиотекой MQTT. Переделал, чтобы туда писался 0 в случае, если подключаемся через сокет.

Кажется, к этому месту ещё придётся вернуться, но сейчас хоть так заткнуть его хотя бы, чтобы работало.