### PR TITLE
Fix readonly topics handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.5.1) stable; urgency=medium
+
+  * Don't crash wb-mqtt-mbgate-confgen on wrong values in readonly topics
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 11 Apr 2023 13:23:53 +0500
+
 wb-mqtt-mbgate (1.5.0) stable; urgency=medium
 
   * Use mqtt client wrapper from wb-common

--- a/utils/generate_config.py
+++ b/utils/generate_config.py
@@ -251,8 +251,12 @@ def mqtt_on_message(arg0, arg1, arg2=None):
         elif mqtt.topic_matches_sub("/devices/+/controls/+", msg.topic):
             table[devName]["value"] = msg.payload
         elif mqtt.topic_matches_sub("/devices/+/controls/+/meta/readonly", msg.topic):
-            if int(msg.payload) == 1:
-                table[devName]["readonly"] = True
+            try:
+                if int(msg.payload) == 1:
+                    table[devName]["readonly"] = True
+            except ValueError:
+                if payloadStr == "true":
+                    table[devName]["readonly"] = True
 
 
 def main(args=None):

--- a/utils/generate_config.py
+++ b/utils/generate_config.py
@@ -257,6 +257,8 @@ def mqtt_on_message(arg0, arg1, arg2=None):
             except ValueError:
                 if payloadStr == "true":
                     table[devName]["readonly"] = True
+                elif payloadStr != "false":
+                    raise
 
 
 def main(args=None):


### PR DESCRIPTION
Don't crash wb-mqtt-mbgate-confgen if readonly topic contains word "false" or "true"