### PR TITLE
Fix schema

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.5.3) stable; urgency=medium
+
+  * Fix error in config editor when switching between rtu and tcp modes
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 16 May 2023 14:39:29 +0500
+
 wb-mqtt-mbgate (1.5.2) stable; urgency=medium
 
   * Fix clang-format, no functional changes

--- a/wb-mqtt-mbgate.schema.json
+++ b/wb-mqtt-mbgate.schema.json
@@ -238,6 +238,9 @@
                 { "$ref": "#/definitions/tcp" },
                 { "$ref": "#/definitions/rtu" }
             ],
+            "options": {
+                "keep_oneof_values": false
+            },
             "propertyOrder": 20,
             "_format": "grid"
         },


### PR DESCRIPTION
Fix error in config editor when switching between rtu and tcp modes

Если пощёлкать tcp/rtu вылезала такая ошибка
![image](https://github.com/wirenboard/wb-mqtt-mbgate/assets/86825564/9b7fa4df-4074-4d6a-9a86-d21d056b198c)
