### PR TITLE
Enable debug logging from libmodbus

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.5.4) stable; urgency=medium
+
+  * Enable debug logging from libmodbus
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 19 May 2023 10:20:00 +0400
+
 wb-mqtt-mbgate (1.5.3) stable; urgency=medium
 
   * Fix error in config editor when switching between rtu and tcp modes

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/wirenboard/wb-mqtt-mbgate
 
 Package: wb-mqtt-mbgate
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3 (>= 3.5), python3-wb-common (>= 2.1.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libmodbus5 (>= 3.0.3), python3 (>= 3.5), python3-wb-common (>= 2.1.0)
 Breaks: wb-mqtt-homeui (<< 1.7)
 Description: Wiren Board MQTT to Modbus gateway
  wb-mqtt-mbgate is a service which acts as Modbus slave on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,7 @@ public:
         tie(modbus, client) = parser.Build();
 
         modbus->AllocateCache();
+        modbus->Backend()->SetDebug(parser.Debug());
         modbus->Backend()->Listen();
 
         return make_tuple(modbus, client);

--- a/src/modbus_lmb_backend.cpp
+++ b/src/modbus_lmb_backend.cpp
@@ -73,6 +73,11 @@ uint8_t TModbusBaseBackend::GetSlave()
     return slaveId;
 }
 
+void TModbusBaseBackend::SetDebug(bool debug)
+{
+    modbus_set_debug(_context, debug ? 1 : 0);
+}
+
 bool TModbusBaseBackend::Available()
 {
     return !QueuedQueries.empty();

--- a/src/modbus_lmb_backend.h
+++ b/src/modbus_lmb_backend.h
@@ -25,6 +25,7 @@ public:
     void AllocateCache(uint8_t slave_id, size_t di, size_t co, size_t ir, size_t hr) override;
     void* GetCache(TStoreType type, uint8_t slave_id = 0) override;
     uint8_t GetSlave() override;
+    void SetDebug(bool debug) override;
     bool Available() override;
     void Reply(const TModbusQuery& q) override;
     void ReplyException(TReplyState e, const TModbusQuery& q) override;

--- a/src/modbus_wrapper.h
+++ b/src/modbus_wrapper.h
@@ -184,6 +184,8 @@ public:
     /*! Get current slave ID */
     virtual uint8_t GetSlave() = 0;
 
+    virtual void SetDebug(bool debug) = 0;
+
     /*! Start listening port/socket */
     virtual void Listen() = 0;
 

--- a/test/fake_modbus_backend.h
+++ b/test/fake_modbus_backend.h
@@ -31,6 +31,9 @@ public:
         return _slaveId;
     }
 
+    virtual void SetDebug(bool debug)
+    {}
+
     virtual void Listen()
     {}
 


### PR DESCRIPTION
1. Enable libmodbus debug logging (https://libmodbus.org/reference/modbus_set_debug/)
2. Add missed dependency (`libmodbus5` was removed from `Depends` in https://github.com/wirenboard/wb-mqtt-mbgate/pull/13)

### Debug enabled, RTU mode
```sh
$ cat /etc/wb-mqtt-mbgate.conf | jq '.debug'
true
$ cat /etc/wb-mqtt-mbgate.conf | jq -r '.modbus.type'
rtu
```

Before:
```sh
<7>DEBUG: [modbus] Modbus cache allocated
<6>INFO: [modbus] Modbus listening
<6>INFO: [mbgate] Start loops
<6>INFO: [mqtt] connection estabilished with code "0" <success>
<6>INFO: [mqtt] subscription succeeded (message id 1)
<6>INFO: [mqtt] subscription succeeded (message id 2)
<7>DEBUG: [modbus] modbus_receive returned -1
```

After:
```sh
<7>DEBUG: [modbus] Modbus cache allocated
Opening /root/pty1 at 115200 bauds (N, 8, 2)
<6>INFO: [modbus] Modbus listening
<6>INFO: [mbgate] Start loops
<6>INFO: [mqtt] connection estabilished with code "0" <success>
<6>INFO: [mqtt] subscription succeeded (message id 1)
<6>INFO: [mqtt] subscription succeeded (message id 2)
Waiting for an indication...
<09><04><00><02><00><01><91><42>
Request for slave 9 ignored (not -1)
<7>DEBUG: [modbus] modbus_receive returned 0
```

### Debug enabled, TCP mode

```sh
$ cat /etc/wb-mqtt-mbgate.conf | jq '.debug'
true
$ cat /etc/wb-mqtt-mbgate.conf | jq -r '.modbus.type'
tcp
```

Before:
```sh
<7>DEBUG: [modbus] Modbus cache allocated
<6>INFO: [modbus] Modbus listening
<6>INFO: [mbgate] Start loops
<6>INFO: [mqtt] connection estabilished with code "0" <success>
<6>INFO: [mqtt] subscription succeeded (message id 1)
<6>INFO: [mqtt] subscription succeeded (message id 2)
<7>DEBUG: [modbus] Modbus incoming connection
<7>DEBUG: [modbus] Modbus closed connection
```

After:
```sh
<7>DEBUG: [modbus] Modbus cache allocated
<6>INFO: [modbus] Modbus listening
<6>INFO: [mbgate] Start loops
<6>INFO: [mqtt] connection estabilished with code "0" <success>
<6>INFO: [mqtt] subscription succeeded (message id 1)
<6>INFO: [mqtt] subscription succeeded (message id 2)
<7>DEBUG: [modbus] Modbus incoming connection
Waiting for an indication...
<00><01><00><00><00><06><09><04><00><02><00><01>
[00][01][00][00][00][05][09][04][02][00][3E]
Waiting for an indication...
ERROR Connection reset by peer: read
<7>DEBUG: [modbus] Modbus closed connection
```