### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: $(BUILD_DIR)/$(TEST_DIR)/$(TEST_TARGET)
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
-		fi \
+		else exit 1; fi; \
 	else \
 		$(BUILD_DIR)/$(TEST_DIR)/$(TEST_TARGET); \
 	fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.5.11) stable; urgency=medium
+
+  * Fix makefile, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 11 Dec 2023 15:00:06 +0400
+
 wb-mqtt-mbgate (1.5.10) stable; urgency=medium
 
   * Handle scale property for float values


### PR DESCRIPTION
Фейл запуска тестов игнорировался и `make test` всегда завершался успешно.