### PR TITLE
Fix CAN exception handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.5.12) stable; urgency=medium
+
+  * Fix can exception handling
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Mon, 18 Dec 2023 22:20:50 +0300
+
 wb-mqtt-mbgate (1.5.11) stable; urgency=medium
 
   * Fix makefile, no functional changes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 
         while (running) {
             if (s->Loop(1000) == -1)
-                throw runtime_error("Error occured in work syscle");
+                throw runtime_error("Error occured in work cycle");
         }
 
         LOG(Info) << "Shutting down";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 
         while (running) {
             if (s->Loop(1000) == -1)
-                throw runtime_error("Error occured in work cycle");
+                throw runtime_error("IO Error occured in server work cycle");
         }
 
         LOG(Info) << "Shutting down";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
 
         while (running) {
             if (s->Loop(1000) == -1)
-                break;
+                throw runtime_error("Error occured in work syscle");
         }
 
         LOG(Info) << "Shutting down";

--- a/src/modbus_lmb_backend.cpp
+++ b/src/modbus_lmb_backend.cpp
@@ -138,9 +138,9 @@ int TModbusBaseBackend::GetError()
     return _error;
 }
 
-const char* TModbusBaseBackend::GetStrError()
+std::string TModbusBaseBackend::GetStrError()
 {
-    return (char*)modbus_strerror(_error);
+    return std::string("libmodbus error: ") + std::string((char*)modbus_strerror(_error));
 }
 
 TModbusQuery TModbusBaseBackend::ReceiveQuery(bool block)

--- a/src/modbus_lmb_backend.cpp
+++ b/src/modbus_lmb_backend.cpp
@@ -315,7 +315,8 @@ int TModbusRTUBackend::WaitForMessages(int timeout)
         ++num_msgs;
     } else {
         // TODO: error handling
-        LOG(Debug) << "modbus_receive returned " << rc;
+        LOG(Error) << "modbus_receive returned " << rc;
+        return rc;
     }
 
     return num_msgs;

--- a/src/modbus_lmb_backend.cpp
+++ b/src/modbus_lmb_backend.cpp
@@ -138,6 +138,11 @@ int TModbusBaseBackend::GetError()
     return _error;
 }
 
+const char* TModbusBaseBackend::GetStrError()
+{
+    return (char*)modbus_strerror(_error);
+}
+
 TModbusQuery TModbusBaseBackend::ReceiveQuery(bool block)
 {
     if (block && !Available())
@@ -315,8 +320,11 @@ int TModbusRTUBackend::WaitForMessages(int timeout)
         ++num_msgs;
     } else {
         // TODO: error handling
-        LOG(Error) << "modbus_receive returned " << rc;
-        return rc;
+        LOG(Debug) << "modbus_receive returned " << rc;
+        if (rc < 0) {
+            _error = errno;
+            return rc;
+        }
     }
 
     return num_msgs;

--- a/src/modbus_lmb_backend.h
+++ b/src/modbus_lmb_backend.h
@@ -30,7 +30,7 @@ public:
     void Reply(const TModbusQuery& q) override;
     void ReplyException(TReplyState e, const TModbusQuery& q) override;
     int GetError() override;
-    const char* GetStrError() override;
+    std::string GetStrError() override;
     TModbusQuery ReceiveQuery(bool block = false) override;
 
 protected:

--- a/src/modbus_lmb_backend.h
+++ b/src/modbus_lmb_backend.h
@@ -30,6 +30,7 @@ public:
     void Reply(const TModbusQuery& q) override;
     void ReplyException(TReplyState e, const TModbusQuery& q) override;
     int GetError() override;
+    const char* GetStrError() override;
     TModbusQuery ReceiveQuery(bool block = false) override;
 
 protected:

--- a/src/modbus_wrapper.cpp
+++ b/src/modbus_wrapper.cpp
@@ -3,6 +3,8 @@
 
 #include <map>
 
+#define LOG(logger) ::logger.Log() << "[modbus] "
+
 using namespace std;
 
 TModbusServer::TModbusServer(PModbusBackend backend): mb(backend)
@@ -114,14 +116,16 @@ void TModbusServer::AllocateCache()
         _callCacheAllocate(_hr, slave_id, HOLDING_REGISTER, mb->GetCache(HOLDING_REGISTER, slave_id));
     }
 
-    Debug.Log() << "[modbus] Modbus cache allocated";
+    LOG(Debug) << "Modbus cache allocated";
 }
 
 int TModbusServer::Loop(int timeoutMilliS)
 {
-    int rc;
-    if ((rc = mb->WaitForMessages(timeoutMilliS)) == -1)
+    int rc = mb->WaitForMessages(timeoutMilliS);
+    if (rc == -1) {
+        LOG(Error) << mb->GetStrError();
         return -1;
+    }
 
     // receive message, process, run callback
     while (mb->Available()) {

--- a/src/modbus_wrapper.h
+++ b/src/modbus_wrapper.h
@@ -234,6 +234,9 @@ public:
     /*! Get last error code */
     virtual int GetError() = 0;
 
+    /*! Get last error message*/
+    virtual const char* GetStrError() = 0;
+
     /*! Close connection */
     virtual void Close() = 0;
 

--- a/src/modbus_wrapper.h
+++ b/src/modbus_wrapper.h
@@ -235,7 +235,7 @@ public:
     virtual int GetError() = 0;
 
     /*! Get last error message*/
-    virtual const char* GetStrError() = 0;
+    virtual std::string GetStrError() = 0;
 
     /*! Close connection */
     virtual void Close() = 0;

--- a/test/fake_modbus_backend.h
+++ b/test/fake_modbus_backend.h
@@ -117,7 +117,7 @@ public:
     }
 
     /*! Get last error message*/
-    virtual const char* GetStrError()
+    virtual std::string GetStrError()
     {
         return "";
     }

--- a/test/fake_modbus_backend.h
+++ b/test/fake_modbus_backend.h
@@ -116,6 +116,12 @@ public:
         return 0;
     }
 
+    /*! Get last error message*/
+    virtual const char* GetStrError()
+    {
+        return "";
+    }
+
     /***********************************************
      * Fake backend methods
      */


### PR DESCRIPTION
Когда сконфигурен CAN, порт может открыться, а прочитаться из него - нет. При этом ошибка IO наверх никак не пробрасывалась и все крутилось в цикле как будто все ок. Добавила передачу ошибки наверх + исключение чтобы сервис упал.