### PR TITLE
Fix unattended config rewriting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,5 +83,6 @@ install:
 	install -Dm0644 wb-mqtt-mbgate.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
 	install -Dm0755 utils/generate_config.py $(DESTDIR)$(PREFIX)/bin/wb-mqtt-mbgate-confgen
 	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin
+	install -Dm0644 wb-mqtt-mbgate.sample.conf $(DESTDIR)$(PREFIX)/share/wb-mqtt-mbgate/wb-mqtt-mbgate.sample.conf
 
 .PHONY: all test clean

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.6.0) stable; urgency=medium
+
+  * Fix unattended config rewriting
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 21 Feb 2024 11:52:24 +0500
+
 wb-mqtt-mbgate (1.5.14) stable; urgency=medium
 
   * Fix clang-tidy issues. No functional changes

--- a/debian/wb-mqtt-mbgate.postinst
+++ b/debian/wb-mqtt-mbgate.postinst
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+CONFFILE=/etc/wb-mqtt-mbgate.conf
+
+if [ ! -e $CONFFILE ]; then
+    cp /usr/share/wb-mqtt-mbgate/wb-mqtt-mbgate.sample.conf $CONFFILE
+fi
+
+#DEBHELPER#

--- a/debian/wb-mqtt-mbgate.postrm
+++ b/debian/wb-mqtt-mbgate.postrm
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CONFFILE=/etc/wb-mqtt-mbgate.conf
+
+if [ "$1" = "purge" ]; then
+    rm -f $CONFFILE
+fi
+
+#DEBHELPER#

--- a/debian/wb-mqtt-mbgate.service
+++ b/debian/wb-mqtt-mbgate.service
@@ -6,7 +6,7 @@ After=wb-configs.service
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=10
 User=root
 ExecStart=/usr/bin/wb-mqtt-mbgate -c /etc/wb-mqtt-mbgate.conf
 ExecStartPre=/usr/bin/wb-mqtt-mbgate-confgen -c /etc/wb-mqtt-mbgate.conf

--- a/utils/generate_config.py
+++ b/utils/generate_config.py
@@ -293,6 +293,7 @@ def main(args=None):
 
             except:
                 print("Failed to open config")
+                sys.exit(1)
 
         config_file = open(args.config, "w")
 

--- a/wb-mqtt-mbgate.sample.conf
+++ b/wb-mqtt-mbgate.sample.conf
@@ -1,0 +1,18 @@
+{
+ "debug": false,
+ "modbus": {
+  "host": "*",
+  "port": 502
+ },
+ "mqtt": {
+  "host": "/var/run/mosquitto/mosquitto.sock",
+  "port": 0
+ },
+ "registers": {
+  "remap_values": false,
+  "discretes": [],
+  "coils": [],
+  "inputs": [],
+  "holdings": []
+ }
+}


### PR DESCRIPTION
Если что-то было не так с конфигом, он перезаписывался. У некоторых пользователей это вызывало панику. Теперь в конфиг только добавляем. Если что-то не так с конфигом, просто падаем