### PR TITLE
fail if no channels enabled

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.6.3) stable; urgency=medium
+
+  * Fail if no channels enabled
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 20 Jun 2024 16:48:25 +0300
+
 wb-mqtt-mbgate (1.6.2) stable; urgency=medium
 
   * Fix size property description

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -113,8 +113,9 @@ tuple<PModbusServer, PMqttClient> TJSONConfigParser::Build()
     any_enabled |= _BuildStore(HOLDING_REGISTER, Root["registers"]["holdings"], modbus, mqtt);
     any_enabled |= _BuildStore(INPUT_REGISTER, Root["registers"]["inputs"], modbus, mqtt);
 
-    if (!any_enabled)
-        throw TConfigException("Found no enabled channels");
+    if (!any_enabled) {
+        throw TConfigException("All channels are disabled");
+    }
 
     return make_tuple(modbus, mqtt);
 }
@@ -126,10 +127,12 @@ bool TJSONConfigParser::_BuildStore(TStoreType type, const Json::Value& list, PM
     bool enabled = false;
 
     for (const auto& reg_item: list) {
-        if (reg_item["enabled"].asBool())
+        if (reg_item["enabled"].asBool()) {
             enabled = true;
-        else
+        }
+        else {
             continue;
+        }
 
         int address = reg_item["address"].asInt();
         int slave_id = reg_item["unitId"].asInt();

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -105,21 +105,30 @@ tuple<PModbusServer, PMqttClient> TJSONConfigParser::Build()
 
     PMqttClient mqtt = NewMosquittoMqttClient(mqtt_config);
 
+    bool any_enabled = false;
+
     // create observers and link'em with MQTT and Modbus
-    _BuildStore(COIL, Root["registers"]["coils"], modbus, mqtt);
-    _BuildStore(DISCRETE_INPUT, Root["registers"]["discretes"], modbus, mqtt);
-    _BuildStore(HOLDING_REGISTER, Root["registers"]["holdings"], modbus, mqtt);
-    _BuildStore(INPUT_REGISTER, Root["registers"]["inputs"], modbus, mqtt);
+    any_enabled |= _BuildStore(COIL, Root["registers"]["coils"], modbus, mqtt);
+    any_enabled |= _BuildStore(DISCRETE_INPUT, Root["registers"]["discretes"], modbus, mqtt);
+    any_enabled |= _BuildStore(HOLDING_REGISTER, Root["registers"]["holdings"], modbus, mqtt);
+    any_enabled |= _BuildStore(INPUT_REGISTER, Root["registers"]["inputs"], modbus, mqtt);
+
+    if (!any_enabled)
+        throw TConfigException("Found no enabled channels");
 
     return make_tuple(modbus, mqtt);
 }
 
-void TJSONConfigParser::_BuildStore(TStoreType type, const Json::Value& list, PModbusServer modbus, PMqttClient mqtt)
+bool TJSONConfigParser::_BuildStore(TStoreType type, const Json::Value& list, PModbusServer modbus, PMqttClient mqtt)
 {
     LOG(Debug) << "Processing store " << type;
 
+    bool enabled = false;
+
     for (const auto& reg_item: list) {
-        if (!reg_item["enabled"].asBool())
+        if (reg_item["enabled"].asBool())
+            enabled = true;
+        else
             continue;
 
         int address = reg_item["address"].asInt();
@@ -176,4 +185,5 @@ void TJSONConfigParser::_BuildStore(TStoreType type, const Json::Value& list, PM
             throw TConfigException(string("Address overlapping: ") + StoreTypeToString(type) + ": topic " + topic);
         }
     }
+    return enabled;
 }

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -39,7 +39,7 @@ public:
     virtual bool Debug();
 
 private:
-    void _BuildStore(TStoreType type, const Json::Value& list, PModbusServer modbus, WBMQTT::PMqttClient mqtt);
+    bool _BuildStore(TStoreType type, const Json::Value& list, PModbusServer modbus, WBMQTT::PMqttClient mqtt);
 
 protected:
     Json::Value Root;


### PR DESCRIPTION
увидели, что некоторые сервисы из коробки (даже будучи не настроенными) смотрят в порт наружу
решили, что непорядок

теперь - пока не включить какой-то канал в webui:
![image](https://github.com/wirenboard/wb-mqtt-mbgate/assets/25829054/aedf01c6-c2df-4840-abdc-c8d816fe931a)
