### PR TITLE
Fix holding registers detection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.6.4) stable; urgency=medium
+
+  * Fix holding registers detection
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 05 Jul 2024 17:08:31 +0500
+
 wb-mqtt-mbgate (1.6.3) stable; urgency=medium
 
   * Fail if no channels enabled

--- a/utils/generate_config.py
+++ b/utils/generate_config.py
@@ -256,8 +256,7 @@ def mqtt_on_message(arg0, arg1, arg2=None):
             table[devName]["value"] = msg.payload
         elif mqtt.topic_matches_sub("/devices/+/controls/+/meta/readonly", msg.topic):
             try:
-                if int(msg.payload) == 1:
-                    table[devName]["readonly"] = True
+                table[devName]["readonly"] = (int(msg.payload) == 1)
             except ValueError:
                 if payloadStr == "true":
                     table[devName]["readonly"] = True


### PR DESCRIPTION
Если `msg.payload == 0`, `table[devName]["readonly"]` не менялось, хотя оно могло быть установлено в `True` ранее веточкой
```python
# FIXME: crazy read-onlys
if "readonly" not in table[devName]:
    if payloadStr in ["switch", "pushbutton", "range", "rgb"]:
        table[devName]["readonly"] = False
    else:
        table[devName]["readonly"] = True
```