### PR TITLE
Fix "Regenerate config" checkbox visibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.7.2-wb100) stable; urgency=medium
+
+  * Fix "Regenerate config" checkbox visibility
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 18 Sep 2024 18:10:00 +0400
+
 wb-mqtt-mbgate (1.7.2) stable; urgency=medium
 
   * Make service not fail on empty configuration

--- a/wb-mqtt-mbgate.schema.json
+++ b/wb-mqtt-mbgate.schema.json
@@ -226,7 +226,12 @@
             "description": "regenerate_config_description",
             "default": false,
             "_format": "checkbox",
-            "propertyOrder": 5
+            "propertyOrder": 5,
+            "options": {
+                "wb": {
+                    "show_editor": true
+                }
+            }
         },
         "debug": {
             "type": "boolean",


### PR DESCRIPTION
Follow up https://github.com/wirenboard/wb-mqtt-mbgate/pull/44
