### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '75'
+               defaultCoverageMin: '70'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '75'

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ TEST_LDFLAGS = -lgtest -lgmock
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DEB_VERSION := $(shell head -1 debian/changelog | awk '{ print $$2 }' | sed 's/[
 
 TARGET = wb-mqtt-mbgate
 SRC_DIR = src
-COMMON_SRCS := $(shell find $(SRC_DIR) -name *.cpp -and -not -name main.cpp)
+COMMON_SRCS := $(shell find $(SRC_DIR) -name "*.cpp" -and -not -name main.cpp)
 COMMON_OBJS := $(COMMON_SRCS:%=$(BUILD_DIR)/%.o)
 
 CXXFLAGS = -std=c++14 -Wall -Werror -I$(SRC_DIR) -DWBMQTT_COMMIT="$(GIT_REVISION)" -DWBMQTT_VERSION="$(DEB_VERSION)"
@@ -32,17 +32,23 @@ LDFLAGS = -lmodbus -lwbmqtt1 -lpthread
 ifeq ($(DEBUG),)
 	CXXFLAGS += -O2
 else
-	CXXFLAGS += -g -O0 -fprofile-arcs -ftest-coverage -Wno-error=cpp
-	LDFLAGS += -lgcov
+	CXXFLAGS += -g -O0 --coverage -Wno-error=cpp
+	LDFLAGS += --coverage
 endif
 
 TEST_DIR = test
-TEST_SRCS := $(shell find $(TEST_DIR) -name *.cpp)
+TEST_SRCS := $(shell find $(TEST_DIR) -name "*.cpp")
 TEST_OBJS := $(TEST_SRCS:%=$(BUILD_DIR)/%.o)
 TEST_TARGET = test-app
 TEST_LDFLAGS = -lgtest -lgmock
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
+
+COV_REPORT ?= $(BUILD_DIR)/cov.html
+GCOVR_FLAGS := --html $(COV_REPORT)
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
 
 all: $(BUILD_DIR)/$(TARGET)
 
@@ -66,11 +72,8 @@ test: $(BUILD_DIR)/$(TEST_DIR)/$(TEST_TARGET)
 	else \
 		$(BUILD_DIR)/$(TEST_DIR)/$(TEST_TARGET); \
 	fi
-
-lcov: test
-ifeq ($(DEBUG), 1)
-	geninfo --no-external -b . -o $(BUILD_DIR)/coverage.info $(BUILD_DIR)/src
-	genhtml $(BUILD_DIR)/coverage.info -o $(BUILD_DIR)/cov_html
+ifneq ($(DEBUG),)
+	gcovr $(GCOVR_FLAGS) $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)
 endif
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,6 @@ install:
 	install -Dm0644 wb-mqtt-mbgate.wbconfigs $(DESTDIR)/etc/wb-configs.d/31wb-mqtt-mbgate
 	install -Dm0644 wb-mqtt-mbgate.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
 	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin
-	install -Dm0644 wb-mqtt-mbgate.sample.conf $(DESTDIR)$(PREFIX)/share/wb-mqtt-mbgate/wb-mqtt-mbgate.sample.conf
+	install -Dm0644 wb-mqtt-mbgate.sample.conf -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-mbgate
 
 .PHONY: all test clean

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ TEST_LDFLAGS = -lgtest -lgmock
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.2) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-mbgate (1.8.1) stable; urgency=medium
 
   * Fix schema compatibility

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,15 @@
 Source: wb-mqtt-mbgate
-Maintainer: Nikita Maslov <nikita.maslov@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev, libmodbus-dev (>= 3.0.3), libgmock-dev, git
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               git,
+               libgmock-dev,
+               libmodbus-dev (>= 3.0.3),
+               libwbmqtt1-5-dev,
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-mbgate
 
 Package: wb-mqtt-mbgate

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,18 @@
 #!/usr/bin/make -f
 
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 override_dh_installinit:
 	dh_installinit --noscripts
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=75 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-9-30 kello 15 48 10" src="https://github.com/user-attachments/assets/830bae8d-cb87-4f3d-a7bd-79d9b9f49663">
