### PR TITLE
Fix service restart on CRC error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.3) stable; urgency=medium
+
+  * Fix service restart on CRC error
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 18 Nov 2024 15:51:45 +0300
+
 wb-mqtt-mbgate (1.8.2) stable; urgency=medium
 
   * Add coverage report generation, no functional changes

--- a/src/modbus_lmb_backend.cpp
+++ b/src/modbus_lmb_backend.cpp
@@ -320,7 +320,7 @@ int TModbusRTUBackend::WaitForMessages(int timeout)
         ++num_msgs;
     } else {
         // TODO: error handling
-        LOG(Debug) << "modbus_receive returned " << rc;
+        LOG(Debug) << "modbus_receive returned " << rc << " errno " << errno;
         if (rc < 0) {
             _error = errno;
             return rc;


### PR DESCRIPTION
поправила перезапуск сервиса по ошибке CRC
Раньше сервис на любые ошибки просто выводил сообщение и продолжал работать, до того как нашли проблему что сервис грузит CPU 100% если RS485-2 сконфигурен на CAN. Поэтому сделала так чтобы при ошибке, которая возникает как при CAN, сервис перезапускался, во всех остальных случаях выводил ошибку