### PR TITLE
Set QoS and retained when publishing to /on

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.4) stable; urgency=medium
+
+  * Fix writing to coils
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 26 Dec 2024 11:34:12 +0500
+
 wb-mqtt-mbgate (1.8.3) stable; urgency=medium
 
   * Fix service restart on CRC error

--- a/src/observer.cpp
+++ b/src/observer.cpp
@@ -38,9 +38,7 @@ TReplyState TGatewayObserver::OnSetValue(TStoreType type,
                                          const void* data)
 {
 
-    TMqttMessage msg;
-    msg.Payload = Conv->Unpack(data, count);
-    msg.Topic = Topic + "/on";
+    TMqttMessage msg(Topic + "/on", Conv->Unpack(data, count), 1, false);
 
     Mqtt->Publish(msg);
 


### PR DESCRIPTION
Не задавались QoS и Retained. Они в конструкторе TMqttMessage не инициализируются, получался мусор внутри. libmosquitto иногда ругалось, что параметры левые, и ничего не делало