### PR TITLE
Fix string registers convertion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.5) stable; urgency=medium
+
+  * Fix string registers conversion
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 11 Mar 2025 09:54:07 +0300
+
 wb-mqtt-mbgate (1.8.4) stable; urgency=medium
 
   * Fix writing to coils

--- a/src/mqtt_converters.cpp
+++ b/src/mqtt_converters.cpp
@@ -358,7 +358,11 @@ string TMQTTTextConverter::Unpack(const void* _data, size_t size) const
             ss << data[(ByteSwap ? (2 * i + 1) : (2 * i))];
     }
 
-    return ss.str();
+    auto result = ss.str();
+    auto pos = result.find('\0');
+    if (pos != string::npos)
+        result = result.erase(pos);
+    return result;
 }
 
 void* TMQTTTextConverter::Pack(const std::string& value, void* _data, size_t size)

--- a/src/mqtt_converters.cpp
+++ b/src/mqtt_converters.cpp
@@ -366,8 +366,8 @@ void* TMQTTTextConverter::Pack(const std::string& value, void* _data, size_t siz
     stringstream ss;
     char* data = static_cast<char*>(_data);
 
-    ss << value;
-
+    ss << value << std::setw(Size - value.size()) << std::setfill((char)0) << "";
+    
     if (WordSwap) {
         for (int i = Size - 1; i >= 0; i--)
             ss >> data[(ByteSwap ? (2 * i + 1) : (2 * i))];

--- a/src/mqtt_converters.cpp
+++ b/src/mqtt_converters.cpp
@@ -367,7 +367,7 @@ void* TMQTTTextConverter::Pack(const std::string& value, void* _data, size_t siz
     char* data = static_cast<char*>(_data);
 
     ss << value << std::setw(Size - value.size()) << std::setfill((char)0) << "";
-    
+
     if (WordSwap) {
         for (int i = Size - 1; i >= 0; i--)
             ss >> data[(ByteSwap ? (2 * i + 1) : (2 * i))];

--- a/test/converters_test.cpp
+++ b/test/converters_test.cpp
@@ -154,7 +154,7 @@ TEST_F(MQTTConvertersTest, TextTest)
     EXPECT_THAT(buffer, ElementsAre('H', 'e', 'l', 'l', 'o', '1', '2', '3', '4', '5'));
     result = t.Unpack(buffer, 10);
     EXPECT_EQ(result, "Hello1234");
-    memset(buffer, 0, 20); 
+    memset(buffer, 0, 20);
 }
 
 TEST_F(MQTTConvertersTest, DiscreteTest)

--- a/test/converters_test.cpp
+++ b/test/converters_test.cpp
@@ -153,7 +153,7 @@ TEST_F(MQTTConvertersTest, TextTest)
     t.Pack(val, buffer, 10);
     EXPECT_THAT(buffer, ElementsAre('H', 'e', 'l', 'l', 'o', '1', '2', '3', '4', '5'));
     result = t.Unpack(buffer, 10);
-    EXPECT_EQ(result, "Hello1234");
+    EXPECT_EQ(result, "Hello12345");
     memset(buffer, 0, 20);
 }
 

--- a/test/converters_test.cpp
+++ b/test/converters_test.cpp
@@ -141,6 +141,20 @@ TEST_F(MQTTConvertersTest, TextTest)
     result = tbw.Unpack(buffer, 10);
     EXPECT_EQ(result, val);
     memset(buffer, 0, 20);
+
+    val = "Hello";
+    t.Pack(val, buffer, 10);
+    EXPECT_THAT(buffer, ElementsAre('H', 'e', 'l', 'l', 'o', 0, 0, 0, 0, 0));
+    result = t.Unpack(buffer, 10);
+    EXPECT_EQ(result, val);
+    memset(buffer, 0, 20);
+
+    val = "Hello1234567890";
+    t.Pack(val, buffer, 10);
+    EXPECT_THAT(buffer, ElementsAre('H', 'e', 'l', 'l', 'o', '1', '2', '3', '4', '5'));
+    result = t.Unpack(buffer, 10);
+    EXPECT_EQ(result, "Hello1234");
+    memset(buffer, 0, 20); 
 }
 
 TEST_F(MQTTConvertersTest, DiscreteTest)


### PR DESCRIPTION
В случае если длина строк из топика короче заданного размера, буфер дополнялся мусором, поправила
https://wirenboard.youtrack.cloud/issue/SOFT-4996/Krivaya-obrabotka-strok-v-wb-mqtt-mbgate