### PR TITLE
Fix build with gcc14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.6) stable; urgency=medium
+
+  * Fix build with gcc14
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 31 Mar 2025 16:30:00 +0400
+
 wb-mqtt-mbgate (1.8.5) stable; urgency=medium
 
   * Fix string registers conversion

--- a/src/mqtt_converters.cpp
+++ b/src/mqtt_converters.cpp
@@ -126,6 +126,7 @@ string TMQTTIntConverter::Unpack(const void* _data, size_t size) const
                 int16_t val;
                 uint16_t regs[1];
             };
+            uval = 0;
 
             PROCESS_VALS();
         } break;
@@ -136,6 +137,7 @@ string TMQTTIntConverter::Unpack(const void* _data, size_t size) const
                 int32_t val;
                 uint16_t regs[2];
             };
+            uval = 0;
 
             PROCESS_VALS();
         } break;
@@ -146,6 +148,7 @@ string TMQTTIntConverter::Unpack(const void* _data, size_t size) const
                 int64_t val;
                 uint16_t regs[4];
             };
+            uval = 0;
 
             PROCESS_VALS();
         } break;


### PR DESCRIPTION
```
       > src/mqtt_converters.cpp:100:18: error: '<anonymous>.TMQTTIntConverter::Unpack(const void*, size_t) const::<unnamed union>::uval' may be used uninitialized []
       >   100 |             uval <<= 16; /* NOLINT(clang-diagnostic-shift-count-overflow) */                                           \
       >       |             ~~~~~^~~~~~
```