### PR TITLE
Fix build with gcc15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.7) stable; urgency=medium
+
+  * Fix build with gcc15
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 04 Apr 2025 11:25:00 +0400
+
 wb-mqtt-mbgate (1.8.6) stable; urgency=medium
 
   * Fix build with gcc14

--- a/src/mqtt_converters.cpp
+++ b/src/mqtt_converters.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 
+#include <cstdint>
 #include <iomanip>
 
 #define FLOAT_MAX_WIDTH 15


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
не собирается с последним gcc 15:
```
src/mqtt_converters.cpp:19:21: error: 'uint16_t' was not declared in this scope
   19 |     void _SwapBytes(uint16_t* data, size_t size)
      |                     ^~~~~~~~
src/mqtt_converters.cpp:9:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    8 | #include <iomanip>
  +++ |+#include <cstdint>
    9 |
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
собрал с gcc15

