### PR TITLE
fix varchar register negative size bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-mbgate (1.8.8) stable; urgency=medium
 
-  * Fix varchar register negative size bug
+  * Add function to change negative varchar register size to 1 for compatibility with old version configuration
 
  -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 31 Jul 2025 13:21:45 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-mbgate (1.8.8) stable; urgency=medium
+
+  * Fix varchar register negative size bug
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 31 Jul 2025 13:21:45 +0300
+
 wb-mqtt-mbgate (1.8.7) stable; urgency=medium
 
   * Fix build with gcc15

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -146,6 +146,10 @@ bool TJSONConfigParser::_BuildStore(TStoreType type, const Json::Value& list, PM
             size = reg_item["size"].asInt();
 
             if (format == "varchar") {
+                // old version config may contain varchar registers with negative size value (-1)
+                // set this registers size to 1
+                if (size < 0)
+                    size = 1;
                 conv = make_shared<TMQTTTextConverter>(size, byteswap, wordswap);
             } else if (format == "float") {
                 double scale = reg_item["scale"].asFloat();

--- a/wb-mqtt-mbgate.schema.json
+++ b/wb-mqtt-mbgate.schema.json
@@ -85,7 +85,7 @@
                 "size": {
                     "type": "integer",
                     "title": "Size in bytes (in registers for text)",
-                    "minimum": 0,
+                    "minimum": -1,
                     "propertyOrder": 50
                 },
                 "scale": {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Конфигурационные файлы устаревших версий службы могут содержать отрицательное значение параметра `size` (`-1`) для регистров с типом `varchar`, такая конфигурация не проходит валидацию  после обновления службы на актуальную версию и, как следствие, служба не запускается.
___________________________________
**Что поменялось для пользователей:**
Теперь такие регистры проходят валидацию, а отрицательное значение параметра `size` заменяется на `1` при загрузке кончика.

___________________________________
**Как проверял/а:**
Запустил службу используя конфигурацию от устаревшей версии, прогнал тесты.
